### PR TITLE
Support 'now' as a date

### DIFF
--- a/lib/utils/assignParams.js
+++ b/lib/utils/assignParams.js
@@ -30,7 +30,7 @@ var check = require('check-types');
 
       if (expectedType == 'date') {
 
-        if (check.date(newParams[ key ])) {
+        if (newParams[ key ] == 'now' || check.date(newParams[ key ])) {
           params[ key ] = newParams[ key ];
         }
 


### PR DESCRIPTION
Google Maps supports 'now' as a date